### PR TITLE
fix: traefik-routes 서비스 이름 수정

### DIFF
--- a/charts/argocd/applicationsets/valuefiles/prod/traefik-routes/values.yaml
+++ b/charts/argocd/applicationsets/valuefiles/prod/traefik-routes/values.yaml
@@ -129,7 +129,7 @@ ingressRoutes:
       - name: onedaypillo-fastapi-app
         port: 8000
 
-  - name: fridge2form-admin-dev
+  - name: fridge2fork-dev-admin
     enabled: true
     namespace: fridge2fork-dev
 
@@ -141,5 +141,5 @@ ingressRoutes:
     tlsSecretName: "woohalabs-com-cert"
 
     services:
-      - name: fridge2fork-dev-database
+      - name: fridge2fork-dev-admin
         port: 8000


### PR DESCRIPTION
- fridge2form-admin-dev → fridge2fork-dev-admin으로 변경
- fridge2fork-dev-database → fridge2fork-dev-admin으로 변경
- 서비스 이름 일관성 확보