### PR TITLE
feat: traefik 라우트 설정 업데이트

### DIFF
--- a/charts/argocd/applicationsets/valuefiles/prod/traefik-routes/values.yaml
+++ b/charts/argocd/applicationsets/valuefiles/prod/traefik-routes/values.yaml
@@ -136,10 +136,25 @@ ingressRoutes:
     entryPoints:
       - websecure
 
-    host: "admin-dev.woohalabs.com"
+    host: "admin-api-dev.woohalabs.com"
     pathPrefix: "/fridge2fork"
     tlsSecretName: "woohalabs-com-cert"
 
     services:
       - name: fridge2fork-dev-admin
+        port: 8000
+  
+  - name: fridge2fork-dev-app
+    enabled: true
+    namespace: fridge2fork-dev
+
+    entryPoints:
+      - websecure
+
+    host: "api-dev.woohalabs.com"
+    pathPrefix: "/fridge2fork"
+    tlsSecretName: "woohalabs-com-cert"
+
+    services:
+      - name: fridge2fork-dev-app
         port: 8000


### PR DESCRIPTION
- admin-dev.woohalabs.com을 admin-api-dev.woohalabs.com으로 변경
- fridge2fork-dev-app 라우트 추가 (api-dev.woohalabs.com)