### PR TITLE
feat: fridge2fork 서비스 이름을 app에서 server로 변경

### DIFF
--- a/charts/argocd/applicationsets/valuefiles/prod/traefik-routes/values.yaml
+++ b/charts/argocd/applicationsets/valuefiles/prod/traefik-routes/values.yaml
@@ -159,7 +159,7 @@ ingressRoutes:
       - name: fridge2fork-dev-admin-web
         port: 8000
 
-  - name: fridge2fork-dev-app
+  - name: fridge2fork-dev-server
     enabled: true
     namespace: fridge2fork-dev
 
@@ -171,7 +171,7 @@ ingressRoutes:
     tlsSecretName: "woohalabs-com-cert"
 
     services:
-      - name: fridge2fork-dev-app
+      - name: fridge2fork-dev-server
         port: 8000
 
   - name: fridge2fork-dev-web
@@ -220,7 +220,7 @@ ingressRoutes:
       - name: fridge2fork-prod-admin-web
         port: 8000
 
-  - name: fridge2fork-prod-app
+  - name: fridge2fork-prod-server
     enabled: true
     namespace: fridge2fork
 
@@ -232,7 +232,7 @@ ingressRoutes:
     tlsSecretName: "woohalabs-com-cert"
 
     services:
-      - name: fridge2fork-prod-app
+      - name: fridge2fork-prod-server
         port: 8000
 
   - name: fridge2fork-prod-web


### PR DESCRIPTION
## 변경사항

- fridge2fork-dev-app → fridge2fork-dev-server
- fridge2fork-prod-app → fridge2fork-prod-server

## 목적
traefik 라우팅 설정의 일관성 향상을 위해 서비스 이름을 통일

## 영향
- traefik 라우팅 설정에서 서비스 이름 변경
- 기존 기능에는 영향 없음

## 체크리스트
- [x] 변경사항 확인
- [x] feature 브랜치 생성
- [x] 커밋 및 push
- [x] PR 생성

## Merge 옵션
이 PR은 squash and merge로 병합 가능합니다.