### PR TITLE
fix: traefik routes 서비스 이름 수정

### DIFF
--- a/charts/argocd/applicationsets/valuefiles/prod/traefik-routes/values.yaml
+++ b/charts/argocd/applicationsets/valuefiles/prod/traefik-routes/values.yaml
@@ -232,7 +232,7 @@ ingressRoutes:
     tlsSecretName: "woohalabs-com-cert"
 
     services:
-      - name: fridge2fork-prod-server
+      - name: fridge2fork-server
         port: 8000
 
   - name: fridge2fork-prod-web
@@ -249,3 +249,4 @@ ingressRoutes:
     services:
       - name: fridge2fork-prod-web
         port: 8000
+


### PR DESCRIPTION
## 변경사항
- traefik routes 설정에서 서비스 이름 수정
- 서비스 이름 일관성 확보

## 상세 내용
- **변경 전**: 
- **변경 후**: 
- ingressRoutes 설정에서 서비스 이름 통일
- 파일 끝 개행 문자 추가

## 영향 범위
- 
- traefik 라우팅 설정
- 1개 파일, 3줄 변경

## 병합 옵션
- Squash and merge 권장