### PR TITLE
chore: otel-collector 및 미사용 ArgoCD 앱 설정 파일 제거

### DIFF
--- a/charts/argocd/configurations/prod/apps-otel-collector-cfg.yaml
+++ b/charts/argocd/configurations/prod/apps-otel-collector-cfg.yaml
@@ -1,6 +1,0 @@
-env: prod
-revision: main
-chartName: otel-collector
-appName: otel-collector
-repoURL: https://github.com/ggorockee/infra
-namespace: monitoring

--- a/charts/argocd/configurations/prod/logging-fluent-bit-cfg.yaml
+++ b/charts/argocd/configurations/prod/logging-fluent-bit-cfg.yaml
@@ -1,6 +1,0 @@
-env: prod
-revision: main
-chartName: fluent-bit
-appName: fluent-bit
-repoURL: https://github.com/ggorockee/infra
-namespace: logging

--- a/charts/argocd/configurations/prod/logging-prom-fluent-bit-cfg.yaml
+++ b/charts/argocd/configurations/prod/logging-prom-fluent-bit-cfg.yaml
@@ -1,6 +1,0 @@
-env: prod
-revision: main
-chartName: fluent-bit
-appName: fluent-bit
-repoURL: https://github.com/ggorockee/infra
-namespace: logging

--- a/charts/argocd/configurations/prod/logging-prom-loki-cfg.yaml
+++ b/charts/argocd/configurations/prod/logging-prom-loki-cfg.yaml
@@ -1,6 +1,0 @@
-env: prod
-revision: main
-chartName: loki
-appName: loki
-repoURL: https://github.com/ggorockee/infra
-namespace: logging

--- a/charts/argocd/configurations/prod/monitoring-prom-grafana-cfg.yaml
+++ b/charts/argocd/configurations/prod/monitoring-prom-grafana-cfg.yaml
@@ -1,6 +1,0 @@
-env: prod
-revision: main
-chartName: kube-prometheus-stack
-appName: kube-prometheus-stack
-repoURL: https://github.com/ggorockee/infra
-namespace: monitoring


### PR DESCRIPTION
## Summary
- `apps-otel-collector-cfg.yaml` 제거: `infra-apps-prod` ApplicationSet이 이 파일을 읽어 `otel-collector` 앱을 계속 생성하는 원인
- `logging-fluent-bit-cfg.yaml`, `logging-prom-*`, `monitoring-prom-grafana-cfg.yaml` 제거: 미사용 설정 파일

## Root Cause
`infra-apps-prod` ApplicationSet 패턴:
- 대상: `charts/argocd/configurations/prod/apps-*.yaml`
- `apps-otel-collector-cfg.yaml`이 해당 패턴에 일치 → ArgoCD가 매번 `otel-collector` 앱 생성

## Test plan
- [ ] PR 머지 후 `otel-collector` 앱이 ArgoCD에서 사라지는지 확인