### PR TITLE
fix: yangobot ExternalSecret 추가 및 values 정리

### DIFF
--- a/charts/argocd/applicationsets/valuefiles/prod/yangobot/values.yaml
+++ b/charts/argocd/applicationsets/valuefiles/prod/yangobot/values.yaml
@@ -1,107 +1,20 @@
-# Default values for yangobot.
-# This is a YAML-formatted file.
-# Declare variables to be passed into your templates.
-
-replicaCount: 1
-
 image:
   repository: ggorockee/yangobot
   pullPolicy: Always
-  # Overrides the image tag whose default is the chart appVersion.
-  tag: ""
+  tag: "20260410-c298514"
 
-imagePullSecrets: []
-nameOverride: ""
-fullnameOverride: ""
-
-serviceAccount:
-  # Specifies whether a service account should be created
-  create: true
-  # Automatically mount a ServiceAccount's API credentials?
-  automount: true
-  # Annotations to add to the service account
-  annotations: {}
-  # The name of the service account to use.
-  # If not set and create is true, a name is generated using the fullname template
-  name: ""
-
-podAnnotations: {}
-podLabels: {}
-
-podSecurityContext: {}
-  # fsGroup: 2000
-
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+secret:
+  name: yangobot-credentials
+  lostarkApiKeyRef: LOSTARK_API_KEY
 
 service:
   type: ClusterIP
-  port: 80
+  port: 8080
 
-ingress:
-  enabled: false
-  className: ""
-  annotations: {}
-    # kubernetes.io/ingress.class: nginx
-    # kubernetes.io/tls-acme: "true"
-  hosts:
-    - host: chart-example.local
-      paths:
-        - path: /
-          pathType: ImplementationSpecific
-  tls: []
-  #  - secretName: chart-example-tls
-  #    hosts:
-  #      - chart-example.local
-
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
-
-livenessProbe:
-  httpGet:
-    path: /
-    port: http
-readinessProbe:
-  httpGet:
-    path: /
-    port: http
-
-autoscaling:
-  enabled: false
-  minReplicas: 1
-  maxReplicas: 100
-  targetCPUUtilizationPercentage: 80
-  # targetMemoryUtilizationPercentage: 80
-
-# Additional volumes on the output Deployment definition.
-volumes: []
-# - name: foo
-#   secret:
-#     secretName: mysecret
-#     optional: false
-
-# Additional volumeMounts on the output Deployment definition.
-volumeMounts: []
-# - name: foo
-#   mountPath: "/etc/foo"
-#   readOnly: true
-
-nodeSelector: {}
-
-tolerations: []
-
-affinity: {}
+resources:
+  requests:
+    cpu: 20m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi

--- a/charts/helm/prod/yangobot/templates/externalsecret.yaml
+++ b/charts/helm/prod/yangobot/templates/externalsecret.yaml
@@ -1,0 +1,22 @@
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ include "yangobot.fullname" . }}-credentials
+  labels:
+    {{- include "yangobot.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-10"
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcpsm-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: yangobot-credentials
+    creationPolicy: Owner
+  data:
+    - secretKey: LOSTARK_API_KEY
+      remoteRef:
+        key: prod-yangobot-credentials
+        property: LOSTARK_API_KEY

--- a/charts/helm/prod/yangobot/values.yaml
+++ b/charts/helm/prod/yangobot/values.yaml
@@ -14,8 +14,8 @@ nameOverride: ""
 fullnameOverride: ""
 
 secret:
-  name: yangobot-secrets
-  lostarkApiKeyRef: lostark-api-key
+  name: yangobot-credentials
+  lostarkApiKeyRef: LOSTARK_API_KEY
 
 extraEnv: []
 
@@ -47,7 +47,13 @@ ingress:
           pathType: ImplementationSpecific
   tls: []
 
-resources: {}
+resources:
+  requests:
+    cpu: 20m
+    memory: 64Mi
+  limits:
+    cpu: 100m
+    memory: 128Mi
 
 autoscaling:
   enabled: false


### PR DESCRIPTION
- ExternalSecret 추가 (GCP SM → yangobot-credentials)
- secret name/key 수정 (yangobot-credentials / LOSTARK_API_KEY)
- service.port 8080 수정
- probe 제거
- valuefiles 동기화