### PR TITLE
fix: yangobot ExternalSecret helm hook 어노테이션 제거

### DIFF
--- a/charts/helm/prod/yangobot/templates/externalsecret.yaml
+++ b/charts/helm/prod/yangobot/templates/externalsecret.yaml
@@ -4,9 +4,6 @@ metadata:
   name: {{ include "yangobot.fullname" . }}-credentials
   labels:
     {{- include "yangobot.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-10"
 spec:
   refreshInterval: 1h
   secretStoreRef:


### PR DESCRIPTION
ArgoCD는 helm.sh/hook 어노테이션이 있는 리소스를 일반 리소스로 배포하지 않음. 어노테이션 제거로 ArgoCD가 ExternalSecret을 정상 관리하도록 수정.