### PR TITLE
fix: yangobot REDIS_ADDR 서비스명 수정

### DIFF
--- a/charts/helm/prod/yangobot/templates/deployment.yaml
+++ b/charts/helm/prod/yangobot/templates/deployment.yaml
@@ -48,7 +48,7 @@ spec:
                   name: {{ .Values.secret.name }}
                   key: {{ .Values.secret.lostarkApiKeyRef }}
             - name: REDIS_ADDR
-              value: "{{ include "yangobot.fullname" . }}-redis-master:6379"
+              value: "{{ include "yangobot.fullname" . }}-redis:6379"
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/helm/prod/yangobot/templates/externalsecret.yaml
+++ b/charts/helm/prod/yangobot/templates/externalsecret.yaml
@@ -4,9 +4,6 @@ metadata:
   name: {{ include "yangobot.fullname" . }}-credentials
   labels:
     {{- include "yangobot.labels" . | nindent 4 }}
-  annotations:
-    "helm.sh/hook": pre-install,pre-upgrade
-    "helm.sh/hook-weight": "-10"
 spec:
   refreshInterval: 1h
   secretStoreRef:


### PR DESCRIPTION
yangobot-redis-master → yangobot-redis (실제 K8s 서비스명 일치)