### PR TITLE
ci: Update yangobot image tag to 20260413-435cc8d

### DIFF
--- a/charts/helm/prod/yangobot/values.yaml
+++ b/charts/helm/prod/yangobot/values.yaml
@@ -8,7 +8,7 @@ revisionHistoryLimit: 2
 image:
   repository: ggorockee/yangobot
   pullPolicy: Always
-  tag: "20260413-a1ca874"
+  tag: "20260413-435cc8d"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Superseded by #1060 (20260413-cc59432). 더 최신 이미지 태그가 이미 main에 반영됨.