### PR TITLE
feat: kakao-client 서브차트 추가

### DIFF
--- a/charts/helm/prod/yangobot/Chart.yaml
+++ b/charts/helm/prod/yangobot/Chart.yaml
@@ -28,3 +28,7 @@ dependencies:
   name: redis
   repository: file://./charts/redis
   version: 0.18.0
+- condition: kakao-client.enabled
+  name: kakao-client
+  repository: file://./charts/kakao-client
+  version: 0.1.0

--- a/charts/helm/prod/yangobot/charts/kakao-client/Chart.yaml
+++ b/charts/helm/prod/yangobot/charts/kakao-client/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: kakao-client
+description: 카카오 Loco 프로토콜 서버 사이드 봇
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/helm/prod/yangobot/charts/kakao-client/templates/deployment.yaml
+++ b/charts/helm/prod/yangobot/charts/kakao-client/templates/deployment.yaml
@@ -1,0 +1,50 @@
+{{- if .Values.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kakao-client
+  labels:
+    app.kubernetes.io/name: kakao-client
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  # Loco 프로토콜은 동일 계정 단일 세션만 허용 — 절대 1 이상으로 변경 금지
+  replicas: 1
+  revisionHistoryLimit: 2
+  # RollingUpdate 사용 시 구/신 pod 동시 기동으로 세션 충돌 발생
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kakao-client
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kakao-client
+        app.kubernetes.io/instance: {{ .Release.Name }}
+    spec:
+      containers:
+        - name: kakao-client
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          envFrom:
+            - secretRef:
+                name: {{ .Values.credentialSecret.name }}
+          env:
+            - name: YANGOBOT_API_URL
+              value: {{ .Values.yanbotApiUrl | quote }}
+            - name: CREDENTIAL_PATH
+              value: "/data/credential.json"
+          volumeMounts:
+            - name: data
+              mountPath: /data
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: kakao-client-data
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65534
+{{- end }}

--- a/charts/helm/prod/yangobot/charts/kakao-client/templates/externalsecret.yaml
+++ b/charts/helm/prod/yangobot/charts/kakao-client/templates/externalsecret.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.enabled }}
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: kakao-client-credentials
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcpsm-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: {{ .Values.credentialSecret.name }}
+    creationPolicy: Owner
+  data:
+    - secretKey: KAKAO_EMAIL
+      remoteRef:
+        key: prod-yangobot-credentials
+        property: kakao_email
+    - secretKey: KAKAO_PASSWORD
+      remoteRef:
+        key: prod-yangobot-credentials
+        property: kakao_password
+    - secretKey: ADMIN_USER_IDS
+      remoteRef:
+        key: prod-yangobot-credentials
+        property: admin_user_ids
+{{- end }}

--- a/charts/helm/prod/yangobot/charts/kakao-client/templates/pvc.yaml
+++ b/charts/helm/prod/yangobot/charts/kakao-client/templates/pvc.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kakao-client-data
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass }}
+  {{- end }}
+{{- end }}

--- a/charts/helm/prod/yangobot/charts/kakao-client/values.yaml
+++ b/charts/helm/prod/yangobot/charts/kakao-client/values.yaml
@@ -1,0 +1,26 @@
+enabled: true
+
+image:
+  repository: ggorockee/yangobot-kakao-client
+  pullPolicy: IfNotPresent
+  tag: "latest"
+
+# yangobot 서비스 내부 URL (ClusterIP 서비스명)
+yanbotApiUrl: "http://yangobot"
+
+# GCP Secret Manager에서 생성되는 k8s Secret 이름
+credentialSecret:
+  name: kakao-client-credentials
+
+# 크리덴셜 파일 저장용 PVC
+persistence:
+  size: 10Mi
+  storageClass: ""
+
+resources:
+  requests:
+    cpu: "50m"
+    memory: "128Mi"
+  limits:
+    cpu: "200m"
+    memory: "256Mi"

--- a/charts/helm/prod/yangobot/values.yaml
+++ b/charts/helm/prod/yangobot/values.yaml
@@ -61,6 +61,14 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+kakao-client:
+  enabled: true
+  image:
+    repository: ggorockee/yangobot-kakao-client
+    pullPolicy: IfNotPresent
+    tag: "latest"
+  yanbotApiUrl: "http://yangobot"
+
 redis:
   enabled: true
   architecture: standalone


### PR DESCRIPTION
## Summary
- `charts/helm/prod/yangobot/charts/kakao-client/` 서브차트 신규 생성
- ExternalSecret: `prod-yangobot-credentials` → `kakao-client-credentials` (KAKAO_EMAIL, KAKAO_PASSWORD, ADMIN_USER_IDS)
- Deployment: `replicas=1`, `strategy=Recreate` (Loco 프로토콜 세션 충돌 방지)
- PVC: `/data` 마운트 (`credential.json` 영속화)
- `Chart.yaml`: kakao-client 의존성 추가
- `values.yaml`: `kakao-client.image.tag` 필드 추가

## Notes
- kakao-client는 카카오 Loco WebSocket 상시 연결 봇 (메신저봇R Android 대체)
- 동일 계정 다중 세션 불가 → replicas 절대 1 이상 변경 금지