### PR TITLE
fix: Chart.yaml kakao-client 의존성 제거

### DIFF
--- a/charts/helm/prod/yangobot/Chart.yaml
+++ b/charts/helm/prod/yangobot/Chart.yaml
@@ -28,7 +28,3 @@ dependencies:
   name: redis
   repository: file://./charts/redis
   version: 0.18.0
-- condition: kakao-client.enabled
-  name: kakao-client
-  repository: file://./charts/kakao-client
-  version: 0.1.0


### PR DESCRIPTION
kakao-client 서브차트 제거 후 Chart.yaml 의존성 누락으로 ArgoCD 에러 발생, 제거