### PR TITLE
fix: Chart.yaml kakao-client 의존성 제거

### DIFF
--- a/charts/helm/prod/yangobot/Chart.yaml
+++ b/charts/helm/prod/yangobot/Chart.yaml
@@ -28,7 +28,3 @@ dependencies:
   name: redis
   repository: file://./charts/redis
   version: 0.18.0
-- condition: kakao-client.enabled
-  name: kakao-client
-  repository: file://./charts/kakao-client
-  version: 0.1.0


### PR DESCRIPTION
## Summary
- Chart.yaml에서 kakao-client 서브차트 dependency 항목 제거
- kakao-client 서브차트는 이미 제거되었으나 Chart.yaml에 잔재

Generated with Claude Code