### PR TITLE
ci: Update go-scraper image to 20260419-811e485

### DIFF
--- a/charts/helm/prod/reviewmaps/values.yaml
+++ b/charts/helm/prod/reviewmaps/values.yaml
@@ -508,7 +508,7 @@ go-scraper:
   image:
     repository: ggorockee/go-scraper
     pullPolicy: IfNotPresent
-    tag: "20260409-0327a95"
+    tag: "20260419-811e485"
 
   imagePullSecrets: []
   nameOverride: ""


### PR DESCRIPTION
Auto-generated PR to update go-scraper Docker image tag

**Image**: ggorockee/reviewmaps-go-scraper:20260419-811e485
**Triggered by**: fix: reviewnote 페이지네이션 버그 수정 및 MaxPages 안전장치 추가 (#256)

- ScrapeConfig에 MaxPages 필드 추가 (기본값 500, SCRAPE_MAX_PAGES 환경변수)
- MaxItems 기본값 100 → 0 (무제한)으로 변경
- reviewnote 스크래퍼에서 len(apiResp.Objects) < pageLimit 조건으로 인한 조기 종료 버그 제거
- maxPages 안전장치 추가로 무한루프 방지 (API가 빈 페이지 미반환 케이스 대응)

🤖 Generated by GitHub Actions