### PR TITLE
ci: Update reviewmaps-server image to 20260504-e886d25

### DIFF
--- a/charts/helm/prod/reviewmaps/values.yaml
+++ b/charts/helm/prod/reviewmaps/values.yaml
@@ -185,7 +185,7 @@ server:
     # This sets the pull policy for images.
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "20260106-e4473e7"
+    tag: "20260504-e886d25"
 
   # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   imagePullSecrets: []


### PR DESCRIPTION
Auto-generated PR to update reviewmaps-server Docker image tag

**Image**: ggorockee/reviewmaps-server:20260504-e886d25
**Triggered by**: fix: staticcheck ST1005 - 에러 문자열 마침표 제거 (#259)

🤖 Generated by GitHub Actions