### PR TITLE
ci: Update reviewmaps-server image to 20260504-c3d3e98

### DIFF
--- a/charts/helm/prod/reviewmaps/values.yaml
+++ b/charts/helm/prod/reviewmaps/values.yaml
@@ -185,7 +185,7 @@ server:
     # This sets the pull policy for images.
     pullPolicy: IfNotPresent
     # Overrides the image tag whose default is the chart appVersion.
-    tag: "20260504-e886d25"
+    tag: "20260504-c3d3e98"
 
   # This is for the secrets for pulling an image from a private repository more information can be found here: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
   imagePullSecrets: []


### PR DESCRIPTION
Auto-generated PR to update reviewmaps-server Docker image tag

**Image**: ggorockee/reviewmaps-server:20260504-c3d3e98
**Triggered by**: fix: keyword_alerts_alerts 테이블 deleted_at 컬럼 추가 및 hard delete 적용 (#260)

- keyword_alerts_alerts 테이블에 deleted_at 컬럼이 없어 발생하던 에러 수정
- DeleteKeyword 메서드에서 Unscoped()를 사용하여 soft delete 컬럼 없이도 hard delete 가능하도록 변경
- add_deleted_at_to_keyword_alerts.sql 마이그레이션 파일 추가: deleted_at 컬럼 및 인덱스 생성

🤖 Generated by GitHub Actions