### PR TITLE
feat(terraform): migrate to new GCP project yango-495502

### DIFF
--- a/gcp/terraform/environments/prod/backend.tf
+++ b/gcp/terraform/environments/prod/backend.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.5.0"
 
   backend "gcs" {
-    bucket = "project-2372300d-tfstate"
+    bucket = "yango-495502-tfstate"
     prefix = "env/prod/woohalabs-prod"
   }
 

--- a/gcp/terraform/environments/prod/main.tf
+++ b/gcp/terraform/environments/prod/main.tf
@@ -8,7 +8,6 @@ provider "google-beta" {
   region  = var.region
 }
 
-# Kubernetes and Helm providers for External Secrets deployment
 data "google_client_config" "default" {}
 
 provider "kubernetes" {
@@ -57,7 +56,7 @@ module "gke" {
 # Other modules will be enabled in future phases
 # GKE API has been enabled in GCP project
 
-# Phase 2: Cloud SQL 활성화 (Secret Manager DB credentials 사용)
+# Phase 2: Cloud SQL 활성화
 module "cloud_sql" {
   source = "../../modules/cloud-sql"
 

--- a/gcp/terraform/environments/prod/variables.tf
+++ b/gcp/terraform/environments/prod/variables.tf
@@ -1,7 +1,7 @@
 variable "project_id" {
   description = "GCP 프로젝트 ID"
   type        = string
-  default     = "project-2372300d-c493-447b-8ee"
+  default     = "yango-495502"
 }
 
 variable "region" {


### PR DESCRIPTION
## Summary
- TF state bucket 변경: `project-2372300d-tfstate` → `yango-495502-tfstate`
- project_id 변경: `project-2372300d-c493-447b-8ee` → `yango-495502`
- external_secrets, cloud_sql 모듈 활성화
- kubernetes/helm provider 재활성화

## 이미 적용된 리소스 (로컬 terraform apply 완료)
- GKE 클러스터: woohalabs-prod-gke
- ESO + ClusterSecretStore
- Cloud SQL: prod-woohalabs-cloudsql (Private IP: 10.34.0.3)
- Cloud Armor security policy

## Test plan
- [ ] GCP Terraform Plan 결과 확인 (no changes expected)
- [ ] 이상 없으면 머지