### PR TITLE
fix: yango-495502 마이그레이션 - istio/applicationset/cert-manager 수정

### DIFF
--- a/argocd_yaml/prod-applicationsets-infra.yaml
+++ b/argocd_yaml/prod-applicationsets-infra.yaml
@@ -10,7 +10,8 @@ spec:
       revision: main
       files:
       - path: "charts/argocd/configurations/prod/*-cfg.yaml"
-        exclude: "charts/argocd/configurations/prod/monitoring-*-cfg.yaml"
+      - path: "charts/argocd/configurations/prod/monitoring-*-cfg.yaml"
+        exclude: true
 
   template:
     metadata:

--- a/charts/helm/prod/cert-manager/values.yaml
+++ b/charts/helm/prod/cert-manager/values.yaml
@@ -1517,7 +1517,7 @@ ssl:
     email: "woohaen88@gmail.com"
 
     # GCP Project ID for Cloud DNS
-    gcpProjectId: "project-2372300d-c493-447b-8ee"
+    gcpProjectId: "yango-495502"
 
     # Secret name for Cloud DNS credentials
     dnsSecretName: "clouddns-dns01-solver-sa"

--- a/charts/helm/prod/istio-ingressgateway/values.yaml
+++ b/charts/helm/prod/istio-ingressgateway/values.yaml
@@ -11,6 +11,10 @@ serviceAccount:
   name: istio-ingressgateway
   annotations: {}
 
+# Pod labels for gateway injection (required for sidecar injector webhook)
+labels:
+  istio.io/rev: default
+
 # Pod annotations for gateway injection
 podAnnotations:
   prometheus.io/port: "15020"

--- a/gcp/terraform/environments/prod/backend.tf
+++ b/gcp/terraform/environments/prod/backend.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.5.0"
 
   backend "gcs" {
-    bucket = "project-2372300d-tfstate"
+    bucket = "yango-495502-tfstate"
     prefix = "env/prod/woohalabs-prod"
   }
 

--- a/gcp/terraform/environments/prod/main.tf
+++ b/gcp/terraform/environments/prod/main.tf
@@ -66,9 +66,9 @@ module "cloud_sql" {
   vpc_network_id = module.networking.network_id
 
   # Cloud SQL 설정
-  instance_tier        = "db-g1-small"
-  disk_size_gb         = 20
-  deletion_protection  = true
+  instance_tier       = "db-g1-small"
+  disk_size_gb        = 20
+  deletion_protection = true
 
   depends_on = [module.external_secrets]
 }

--- a/gcp/terraform/environments/prod/main.tf
+++ b/gcp/terraform/environments/prod/main.tf
@@ -8,7 +8,6 @@ provider "google-beta" {
   region  = var.region
 }
 
-# Kubernetes and Helm providers for External Secrets deployment
 data "google_client_config" "default" {}
 
 provider "kubernetes" {
@@ -57,7 +56,7 @@ module "gke" {
 # Other modules will be enabled in future phases
 # GKE API has been enabled in GCP project
 
-# Phase 2: Cloud SQL 활성화 (Secret Manager DB credentials 사용)
+# Phase 2: Cloud SQL 활성화
 module "cloud_sql" {
   source = "../../modules/cloud-sql"
 

--- a/gcp/terraform/environments/prod/variables.tf
+++ b/gcp/terraform/environments/prod/variables.tf
@@ -1,7 +1,7 @@
 variable "project_id" {
   description = "GCP 프로젝트 ID"
   type        = string
-  default     = "project-2372300d-c493-447b-8ee"
+  default     = "yango-495502"
 }
 
 variable "region" {


### PR DESCRIPTION
## Summary

- `istio-ingressgateway` pod labels에 `istio.io/rev: default` 추가 (ErrImagePull 수정)
- `ApplicationSet` git generator `exclude` 필드 타입 boolean으로 수정
- `cert-manager` ClusterIssuer `gcpProjectId` → `yango-495502` 업데이트
- `terraform fmt` 포맷 정렬

## Test plan

- [ ] istio-ingressgateway Pod Running 확인
- [ ] cert-manager ClusterIssuer Ready 확인
- [ ] ArgoCD ApplicationSet 정상 동기화 확인