### PR TITLE
fix: istio-ingressgateway labels 중복 키 수정 및 istio.io/rev 추가

### DIFF
--- a/argocd_yaml/prod-applicationsets-infra.yaml
+++ b/argocd_yaml/prod-applicationsets-infra.yaml
@@ -10,7 +10,8 @@ spec:
       revision: main
       files:
       - path: "charts/argocd/configurations/prod/*-cfg.yaml"
-        exclude: "charts/argocd/configurations/prod/monitoring-*-cfg.yaml"
+      - path: "charts/argocd/configurations/prod/monitoring-*-cfg.yaml"
+        exclude: true
 
   template:
     metadata:

--- a/charts/helm/prod/cert-manager/values.yaml
+++ b/charts/helm/prod/cert-manager/values.yaml
@@ -1517,7 +1517,7 @@ ssl:
     email: "woohaen88@gmail.com"
 
     # GCP Project ID for Cloud DNS
-    gcpProjectId: "project-2372300d-c493-447b-8ee"
+    gcpProjectId: "yango-495502"
 
     # Secret name for Cloud DNS credentials
     dnsSecretName: "clouddns-dns01-solver-sa"

--- a/charts/helm/prod/istio-ingressgateway/values.yaml
+++ b/charts/helm/prod/istio-ingressgateway/values.yaml
@@ -11,6 +11,10 @@ serviceAccount:
   name: istio-ingressgateway
   annotations: {}
 
+# Pod labels for gateway injection (required for sidecar injector webhook)
+labels:
+  istio.io/rev: default
+
 # Pod annotations for gateway injection
 podAnnotations:
   prometheus.io/port: "15020"

--- a/charts/helm/prod/istio-ingressgateway/values.yaml
+++ b/charts/helm/prod/istio-ingressgateway/values.yaml
@@ -11,10 +11,6 @@ serviceAccount:
   name: istio-ingressgateway
   annotations: {}
 
-# Pod labels for gateway injection (required for sidecar injector webhook)
-labels:
-  istio.io/rev: default
-
 # Pod annotations for gateway injection
 podAnnotations:
   prometheus.io/port: "15020"
@@ -65,10 +61,12 @@ env: {}
 
 # Labels for the gateway deployment
 # IMPORTANT: These labels are used for Gateway resource selectors
+# istio.io/rev: default is required for sidecar injector webhook to replace image: auto
 labels:
   istio: ingressgateway
   app: istio-ingressgateway
   "istio.io/dataplane-mode": none
+  "istio.io/rev": default
 
 # Annotations for all resources
 annotations: {}

--- a/gcp/terraform/environments/prod/backend.tf
+++ b/gcp/terraform/environments/prod/backend.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 1.5.0"
 
   backend "gcs" {
-    bucket = "project-2372300d-tfstate"
+    bucket = "yango-495502-tfstate"
     prefix = "env/prod/woohalabs-prod"
   }
 

--- a/gcp/terraform/environments/prod/main.tf
+++ b/gcp/terraform/environments/prod/main.tf
@@ -66,9 +66,9 @@ module "cloud_sql" {
   vpc_network_id = module.networking.network_id
 
   # Cloud SQL 설정
-  instance_tier        = "db-g1-small"
-  disk_size_gb         = 20
-  deletion_protection  = true
+  instance_tier       = "db-g1-small"
+  disk_size_gb        = 20
+  deletion_protection = true
 
   depends_on = [module.external_secrets]
 }

--- a/gcp/terraform/environments/prod/main.tf
+++ b/gcp/terraform/environments/prod/main.tf
@@ -8,7 +8,6 @@ provider "google-beta" {
   region  = var.region
 }
 
-# Kubernetes and Helm providers for External Secrets deployment
 data "google_client_config" "default" {}
 
 provider "kubernetes" {
@@ -57,7 +56,7 @@ module "gke" {
 # Other modules will be enabled in future phases
 # GKE API has been enabled in GCP project
 
-# Phase 2: Cloud SQL 활성화 (Secret Manager DB credentials 사용)
+# Phase 2: Cloud SQL 활성화
 module "cloud_sql" {
   source = "../../modules/cloud-sql"
 

--- a/gcp/terraform/environments/prod/variables.tf
+++ b/gcp/terraform/environments/prod/variables.tf
@@ -1,7 +1,7 @@
 variable "project_id" {
   description = "GCP 프로젝트 ID"
   type        = string
-  default     = "project-2372300d-c493-447b-8ee"
+  default     = "yango-495502"
 }
 
 variable "region" {


### PR DESCRIPTION
## 변경 요약

- `charts/helm/prod/istio-ingressgateway/values.yaml`의 YAML 중복 키 문제 수정

## 문제 원인

YAML 스펙에서 동일한 키가 여러 번 선언될 경우 마지막 값이 우선합니다.
이전 커밋에서 `istio.io/rev: default` 레이블을 파일 최상단에 별도 `labels:` 블록으로 추가했으나,
파일 하단에 이미 `labels:` 블록이 존재하여 최상단 블록이 완전히 무시되는 문제가 있었습니다.

## 변경 내용

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| 최상단 중복 labels 블록 | 존재 (무효) | 제거 |
| `istio.io/rev: default` 레이블 | 중복 블록에만 존재 (무효) | 기존 labels 블록에 통합 (유효) |
| 주석 | 미비 | sidecar injector webhook 요건 명시 |

## 영향 범위

- `istio-ingressgateway` 파드가 `istio.io/rev: default` 레이블을 정상적으로 보유
- sidecar injector webhook의 `image: auto` 치환이 올바르게 동작
- Gateway 리소스 셀렉터와의 매핑 정상화