### PR TITLE
fix: woohalabs.com 루트 경로 /ojeomneo로 redirect 추가

### DIFF
--- a/charts/helm/prod/istio-gateway-config/values.yaml
+++ b/charts/helm/prod/istio-gateway-config/values.yaml
@@ -228,6 +228,16 @@ virtualServices:
           - destination:
               host: ojeomneo-web
               port: 3000
+      - match:
+          - uri:
+              exact: "/"
+        redirect:
+          uri: "/ojeomneo"
+      - match:
+          - uri:
+              exact: ""
+        redirect:
+          uri: "/ojeomneo"
 
   # ReviewMaps Web (전체 도메인)
   - name: reviewmaps-web-vs


### PR DESCRIPTION
## Summary
- woohalabs.com/ 접속 시 404 발생 문제 수정
- ojeomneo-web-vs VirtualService에 루트 경로(/, 빈 path) → /ojeomneo redirect 규칙 추가
- 앱은 /ojeomneo 경로에서 서비스되므로 루트 접속 시 자동 이동

## Test plan
- [ ] https://woohalabs.com → https://woohalabs.com/ojeomneo 로 redirect 확인
- [ ] https://woohalabs.com/ojeomneo → 200 OK 확인
- [ ] https://woohalabs.com/app-ads.txt → 200 OK 확인 (기존 동작 유지)