### PR TITLE
fix: woohalabs.com redirect에서 빈 URI exact 매치 제거

### DIFF
--- a/charts/helm/prod/istio-gateway-config/values.yaml
+++ b/charts/helm/prod/istio-gateway-config/values.yaml
@@ -233,11 +233,6 @@ virtualServices:
               exact: "/"
         redirect:
           uri: "/ojeomneo"
-      - match:
-          - uri:
-              exact: ""
-        redirect:
-          uri: "/ojeomneo"
 
   # ReviewMaps Web (전체 도메인)
   - name: reviewmaps-web-vs


### PR DESCRIPTION
Istio validation webhook 오류 수정: exact: "" 빈 URI 매치는 유효하지 않아 VirtualService Apply 실패. exact: "/" 만 유지.