### PR TITLE
fix: VirtualService Helm 템플릿에 redirect 액션 지원 추가

### DIFF
--- a/charts/helm/prod/istio-gateway-config/templates/virtualservices.yaml
+++ b/charts/helm/prod/istio-gateway-config/templates/virtualservices.yaml
@@ -39,12 +39,25 @@ spec:
       authority: {{ .rewrite.authority | quote }}
       {{- end }}
     {{- end }}
+    {{- if .redirect }}
+    redirect:
+      {{- if .redirect.uri }}
+      uri: {{ .redirect.uri | quote }}
+      {{- end }}
+      {{- if .redirect.authority }}
+      authority: {{ .redirect.authority | quote }}
+      {{- end }}
+      {{- if .redirect.redirectCode }}
+      redirectCode: {{ .redirect.redirectCode }}
+      {{- end }}
+    {{- else if .route }}
     route:
     {{- range .route }}
     - destination:
         host: {{ .destination.host }}
         port:
           number: {{ .destination.port }}
+    {{- end }}
     {{- end }}
   {{- end }}
 {{- end }}


### PR DESCRIPTION
redirect 타입의 HTTP 룰을 VirtualService 템플릿에서 처리하지 못해 ArgoCD sync 실패. route 대신 redirect가 있는 경우 redirect 블록을 렌더링하도록 수정.