### PR TITLE
fix: ggorockee-org TLS 설정 제거

### DIFF
--- a/charts/helm/prod/istio-gateway-config/values.yaml
+++ b/charts/helm/prod/istio-gateway-config/values.yaml
@@ -28,12 +28,6 @@ gateway:
           - "ggorockee.com"
         credentialName: ggorockee-com-wildcard-tls
 
-      - name: ggorockee-org
-        hosts:
-          - "*.ggorockee.org"
-          - "ggorockee.org"
-        credentialName: ggorockee-org-wildcard-tls
-
       - name: woohalabs-com
         hosts:
           - "*.woohalabs.com"


### PR DESCRIPTION
## Summary

- 미사용 도메인(ggorockee.org)에 대한 istio gateway TLS 설정 제거
- istiod에서 `ggorockee-org-wildcard-tls` secret not found 오류 지속 발생
- ggorockee.org 도메인을 현재 사용하지 않으므로 관련 TLS 섹션 삭제

## 변경 파일

- `charts/helm/prod/istio-gateway-config/values.yaml`
  - `ggorockee-org` TLS 섹션 제거 (name, hosts, credentialName 포함)

## Test plan

- [ ] ArgoCD에서 istio-gateway-config 앱 sync 확인
- [ ] istiod 로그에서 secret not found 오류 미발생 확인
- [ ] 기존 서비스(ggorockee.com, woohalabs.com 등) 정상 동작 확인