### PR TITLE
feat: external_secrets 모듈 재활성화 (yango-501407 GKE 부트스트랩 완료)

### DIFF
--- a/gcp/terraform/environments/prod/main.tf
+++ b/gcp/terraform/environments/prod/main.tf
@@ -107,21 +107,17 @@ module "cloud_armor" {
 # }
 
 # Phase 2: External Secrets Operator deployment
-# NOTE: 신규 프로젝트 최초 부트스트랩 시 임시로 비활성화.
-# kubernetes_manifest 리소스는 GKE 클러스터가 이미 존재해야 REST client를 구성할 수 있는데,
-# 최초 apply에서는 GKE 클러스터도 함께 생성되므로 plan 단계에서 실패함.
-# GKE 클러스터가 생성된 뒤 별도 커밋으로 재활성화할 것.
-# module "external_secrets" {
-#   source = "../../modules/external-secrets"
-#
-#   project_id       = var.project_id
-#   region           = var.region
-#   environment      = var.environment
-#   cluster_name     = module.gke.cluster_name
-#   cluster_location = module.gke.cluster_location
-#
-#   depends_on = [module.gke]
-# }
+module "external_secrets" {
+  source = "../../modules/external-secrets"
+
+  project_id       = var.project_id
+  region           = var.region
+  environment      = var.environment
+  cluster_name     = module.gke.cluster_name
+  cluster_location = module.gke.cluster_location
+
+  depends_on = [module.gke]
+}
 
 # Phase 3: ArgoCD deployment
 # NOTE: ArgoCD is now managed by Helm/ArgoCD itself, not by Terraform


### PR DESCRIPTION
## Summary
- feature/migrate-to-yango-501407 PR에서 최초 부트스트랩을 위해 임시 비활성화했던 external_secrets 모듈을 재활성화
- GKE 클러스터(woohalabs-prod-gke)가 yango-501407에 정상 기동된 것을 확인함
- ESO(controller/CRD)는 이 모듈의 helm_release 리소스가 관리하므로, 부트스트랩 중 임시로 수동 설치했던 release/namespace는 제거하고 terraform이 처음부터 관리하도록 정리함

## Test plan
- [ ] CI Terraform Plan에서 external_secrets 모듈 리소스(namespace, GCP SA, workload identity binding, helm_release, ClusterSecretStore)만 추가되는지 확인
- [ ] merge 후 apply 성공, ClusterSecretStore(gcpsm-secret-store) Ready 상태 확인