### PR TITLE
fix: Cloud SQL 프로젝트 이관 시 POSTGRES_HOST 갱신 누락 수정

### DIFF
--- a/gcp/terraform/modules/cloud-sql/main.tf
+++ b/gcp/terraform/modules/cloud-sql/main.tf
@@ -233,7 +233,9 @@ resource "google_sql_user" "reviewmaps" {
 # Secret Manager에 연결 정보 업데이트
 # ============================================================
 
-# Ojeomneo DB 연결 정보 업데이트 (POSTGRES_SERVER를 Cloud SQL Private IP로 변경)
+# Ojeomneo DB 연결 정보 업데이트 (POSTGRES_HOST/POSTGRES_SERVER를 Cloud SQL Private IP로 변경)
+# NOTE: 앱은 POSTGRES_HOST를 실제로 사용함 (POSTGRES_SERVER만 갱신하던 이전 버전은
+# 프로젝트 이관 시 앱이 옛 프로젝트의 Private IP로 계속 연결을 시도하는 버그가 있었음)
 resource "null_resource" "update_ojeomneo_secret" {
   provisioner "local-exec" {
     command = <<-EOT
@@ -242,10 +244,10 @@ resource "null_resource" "update_ojeomneo_secret" {
         --secret=prod-ojeomneo-db-credentials \
         --project=${var.project_id})
 
-      # POSTGRES_SERVER만 Cloud SQL Private IP로 업데이트
+      # POSTGRES_HOST, POSTGRES_SERVER 둘 다 Cloud SQL Private IP로 업데이트
       UPDATED_SECRET=$(echo "$EXISTING_SECRET" | jq \
         --arg server "${google_sql_database_instance.main.private_ip_address}" \
-        '.POSTGRES_SERVER = $server')
+        '.POSTGRES_HOST = $server | .POSTGRES_SERVER = $server')
 
       # 새 버전 추가
       echo -n "$UPDATED_SECRET" | gcloud secrets versions add prod-ojeomneo-db-credentials \
@@ -257,7 +259,7 @@ resource "null_resource" "update_ojeomneo_secret" {
   depends_on = [google_sql_database_instance.main]
 }
 
-# ReviewMaps DB 연결 정보 업데이트 (POSTGRES_SERVER를 Cloud SQL Private IP로 변경)
+# ReviewMaps DB 연결 정보 업데이트 (POSTGRES_HOST/POSTGRES_SERVER를 Cloud SQL Private IP로 변경)
 resource "null_resource" "update_reviewmaps_secret" {
   provisioner "local-exec" {
     command = <<-EOT
@@ -266,10 +268,10 @@ resource "null_resource" "update_reviewmaps_secret" {
         --secret=prod-reviewmaps-db-credentials \
         --project=${var.project_id})
 
-      # POSTGRES_SERVER만 Cloud SQL Private IP로 업데이트
+      # POSTGRES_HOST, POSTGRES_SERVER 둘 다 Cloud SQL Private IP로 업데이트
       UPDATED_SECRET=$(echo "$EXISTING_SECRET" | jq \
         --arg server "${google_sql_database_instance.main.private_ip_address}" \
-        '.POSTGRES_SERVER = $server')
+        '.POSTGRES_HOST = $server | .POSTGRES_SERVER = $server')
 
       # 새 버전 추가
       echo -n "$UPDATED_SECRET" | gcloud secrets versions add prod-reviewmaps-db-credentials \

--- a/gcp/terraform/modules/gke/main.tf
+++ b/gcp/terraform/modules/gke/main.tf
@@ -93,6 +93,10 @@ resource "google_container_node_pool" "spot_pool_medium" {
     min_node_count = 0
     max_node_count = 0
   }
+
+  lifecycle {
+    ignore_changes = [node_count]
+  }
 }
 
 # Node Pool with Spot Instances - e2-highmem-2 (2 vCPU, 16GB RAM)
@@ -138,5 +142,9 @@ resource "google_container_node_pool" "spot_pool_large" {
   autoscaling {
     min_node_count = 2
     max_node_count = 3
+  }
+
+  lifecycle {
+    ignore_changes = [node_count]
   }
 }


### PR DESCRIPTION
## Summary
- yango-501407 이관 중 발견: cloud-sql 모듈의 null_resource가 Secret Manager의 `POSTGRES_SERVER` 필드만 새 Cloud SQL Private IP로 갱신하고, 앱이 실제로 사용하는 `POSTGRES_HOST` 필드는 갱신하지 않아서 ojeomneo/reviewmaps 둘 다 이관 후에도 옛 프로젝트의 Private IP로 DB 연결을 시도하는 문제가 있었음
- reviewmaps는 마이그레이션 Job이 DB 연결 타임아웃으로 계속 실패, ojeomneo는 파드는 Running이지만 실제로는 옛 DB에 연결 시도 중이었음
- `POSTGRES_HOST`, `POSTGRES_SERVER` 둘 다 갱신하도록 수정

## Note
- 이 null_resource는 `google_sql_database_instance.main` 생성 시 1회만 실행되므로(트리거 없음), 이미 존재하는 yango-501407 환경의 시크릿은 이번 PR과 별개로 수동으로 이미 correct 값으로 패치해둠. 이 수정은 향후 신규 프로젝트 이관 시 동일 버그 재발을 막기 위함

## Test plan
- [x] terraform validate 통과
- [ ] 다음 신규 Cloud SQL 인스턴스 생성 시 POSTGRES_HOST가 정상적으로 Private IP로 설정되는지 확인