### PR TITLE
docs: yango-501407 이관 실행 결과 문서화

### DIFF
--- a/claudedocs/migration-to-new-gcp.md
+++ b/claudedocs/migration-to-new-gcp.md
@@ -41,12 +41,14 @@
 ### Phase 1 - Terraform 인프라 배포
 
 - [x] 코드 변경 (아래 "코드 변경 사항 요약" 참고)
-- [ ] GitHub Repository Secrets 업데이트
+- [x] GitHub Repository Secrets 업데이트
   - `GCP_PROJECT_ID` → `yango-501407`
   - `GCP_SA_KEY` → 새 서비스 계정 키 내용 (JSON)
-- [ ] feature 브랜치 PR → main 머지
-- [ ] GitHub Actions `gcp-terraform-apply` 워크플로우 성공 확인
-- [ ] 신규 GKE 클러스터 접근 확인
+- [x] feature 브랜치 PR → main 머지 (#1096, #1097, #1098)
+- [x] GitHub Actions `gcp-terraform-apply` 워크플로우 성공 확인
+- [x] 신규 GKE 클러스터 접근 확인
+
+**실행 중 발견된 이슈**: `external_secrets` 모듈(kubernetes_manifest 리소스)은 GKE 클러스터가 이미 떠 있어야 REST client를 구성할 수 있는데, 최초 apply에서는 GKE도 함께 생성되므로 plan이 실패함. 최초 apply에서는 해당 모듈을 비활성화하고, GKE 생성 완료 후 별도 PR(#1097)로 재활성화하는 2단계 부트스트랩으로 처리함. 그 과정에서 External Secrets Operator CRD도 Helm 릴리스와 별개로 먼저 설치해야 하는 동일한 순서 문제가 있어 CRD만 먼저 적용 후 소유권 라벨을 붙여 Helm이 입양하도록 처리함.
 
 **배포되는 리소스:**
 
@@ -60,10 +62,10 @@
 
 ### Phase 2 - Secret Manager 시크릿 이관
 
-- [ ] 기존 프로젝트 시크릿 목록 확인 (`gcloud secrets list --project=yango-495502`)
-- [ ] 새 프로젝트에 시크릿 재등록
+- [x] 기존 프로젝트 시크릿 목록 확인 (`gcloud secrets list --project=yango-495502`)
+- [x] 새 프로젝트에 시크릿 재등록
 
-**이관 대상 시크릿 (총 18개, 코드 스캔 기준 — 이전 문서엔 15개만 기재되어 있었음):**
+**실제로는 13개만 존재했음** (아래 표는 코드 스캔 기준 예상 목록이며, `argocd-dex-google-client-id/secret`, `argocd-admin-password`, `argocd-admin-emails`는 `prod-argocd-dex-credentials` 하나로 통합되어 있었고, `prod-sybot-credentials`는 아직 생성된 적이 없었음). 실제 목록 기준 13개를 그대로 이관함.
 
 | 시크릿 이름 | 용도 |
 |------------|------|
@@ -94,57 +96,63 @@
 
 ### Phase 3 - Cloud SQL 데이터 이관
 
-- [ ] 기존 Cloud SQL에서 pg_dump 실행
-- [ ] 신규 Cloud SQL에 restore
-- [ ] 데이터 정합성 확인
+- [x] 기존 Cloud SQL에서 export 실행
+- [x] 신규 Cloud SQL에 import
+- [x] 데이터 정합성 확인 (export 후 재검증용으로 새 인스턴스에서 다시 export하여 파일 크기 바이트 단위 일치 확인)
 
-**이관 절차:**
+**실제로 사용한 절차** (계획했던 Cloud SQL Auth Proxy + pg_dump/psql 대신, 네트워크 접근 불필요한 서버사이드 export/import 사용):
 
-1. Cloud SQL Auth Proxy로 기존 DB 연결: `cloud-sql-proxy yango-495502:asia-northeast3:prod-woohalabs-cloudsql`
-2. pg_dump 실행
-   - `pg_dump -h 127.0.0.1 -U ojeomneo_user ojeomneo > ojeomneo_backup.sql`
-   - `pg_dump -h 127.0.0.1 -U reviewmaps_user reviewmaps > reviewmaps_backup.sql`
-3. 새 Cloud SQL Auth Proxy 연결: `cloud-sql-proxy yango-501407:asia-northeast3:prod-woohalabs-cloudsql`
-4. restore 실행 (reviewmaps는 `pgcrypto`, `postgis` 확장 선설치 필요)
-   - `psql -h 127.0.0.1 -U ojeomneo_user ojeomneo < ojeomneo_backup.sql`
-   - `psql -h 127.0.0.1 -U reviewmaps_user reviewmaps < reviewmaps_backup.sql`
+1. `gcloud sql export sql prod-woohalabs-cloudsql gs://[BUCKET]/[DB].sql --database=[DB] --project=yango-495502`
+2. GCS 버킷에 대해 새 프로젝트 Cloud SQL 서비스 계정에 `storage.objectViewer` 임시 부여
+3. `gcloud sql import sql prod-woohalabs-cloudsql gs://[BUCKET]/[DB].sql --database=[DB] --project=yango-501407`
+4. 검증 후 임시 버킷/권한 정리
 
-참고: `kubernetes/jobs/cloud-sql-restore/{ojeomneo,reviewmaps}/`에 지난 이관 때 쓰던 Job 매니페스트가 남아있음 (Workload Identity 기반 restore). 이번에도 동일 패턴 재사용 가능하나 `service-account.yaml`의 `iam.gke.io/gcp-service-account` 어노테이션이 옛 프로젝트(`infra-480802`)를 가리키고 있어 새 프로젝트 기준으로 SA를 다시 만들고 어노테이션도 갱신해야 함.
+**실행 중 발견된 이슈**:
+
+- 이관 대상 DB가 계획에는 `ojeomneo`, `reviewmaps` 2개였으나, 실제로는 **`hotsao` DB가 하나 더 존재**했음 (Terraform 미관리, 수동 생성분). 위 절차와 동일하게 추가로 이관하고 `gcloud sql databases create hotsao`, `gcloud sql users create hotsao`로 신규 인스턴스에 사전 생성함.
+- `gcp/terraform/modules/cloud-sql/main.tf`의 `null_resource.update_ojeomneo_secret` / `update_reviewmaps_secret`가 Secret Manager의 `POSTGRES_SERVER` 필드만 새 Private IP로 갱신하고, 앱이 실제로 사용하는 `POSTGRES_HOST` 필드는 갱신하지 않아서 이관 후에도 앱이 옛 프로젝트의 Cloud SQL Private IP로 연결을 시도하는 버그를 발견함 (ojeomneo, reviewmaps 둘 다 영향). PR #1098로 코드 수정, 이미 존재하는 시크릿은 수동으로 패치. `hotsao-app-secrets`의 `DB_HOST`도 동일한 문제라 같이 수동 패치함.
 
 ### Phase 4 - 워크로드 이관
 
-- [ ] 새 GKE 클러스터 kubeconfig 설정
-- [ ] ArgoCD 수동 배포 (첫 번째 설치)
-- [ ] ArgoCD에 Git 저장소 연결
-- [ ] ApplicationSets 적용 → 앱 자동 배포 (ojeomneo, reviewmaps, hotsao, sybot, yangobot 포함 여부 확인)
-- [ ] Istio Ingress Gateway IP 확인
+- [x] 새 GKE 클러스터 kubeconfig 설정
+- [x] ArgoCD 수동 배포 (첫 번째 설치, 사용자가 직접 진행)
+- [x] ArgoCD에 Git 저장소 연결
+- [x] ApplicationSets 적용 → 앱 자동 배포 (ojeomneo, reviewmaps, hotsao, istio, cert-manager, gke-backendconfig, gke-storageclass, woohalabs-app-ads, yangobot — 12개 Application 전부 Synced)
+- [x] Istio Ingress Gateway IP 확인 → `34.64.94.80`
 
-**ArgoCD 초기 배포:**
+**실행 중 발견/해결한 이슈**:
 
-- kubeconfig: `gcloud container clusters get-credentials woohalabs-prod-gke --region=asia-northeast3 --project=yango-501407`
-- 설치: `helm upgrade --install argo-cd argo/argo-cd -n argocd --create-namespace -f charts/helm/prod/argo-cd/values.yaml`
+- `istio-ingressgateway` 파드가 istiod의 sidecar-injector webhook이 준비되기 전에 스케줄되어 `image: auto` 상태로 ImagePullBackOff 발생. 파드 삭제로 재생성하여 정상 이미지(`proxyv2`)로 교체됨.
+- `istio-gateway-config`의 `grafana-vs`, `prometheus-vs` VirtualService가 `monitoring` 네임스페이스를 참조하는데, 모니터링 스택(kube-prometheus-stack) 자체가 저장소에서 의도적으로 비활성화되어 있어 네임스페이스가 없어 동기화 실패. `monitoring` 네임스페이스만 생성해서 해결 (모니터링 앱 자체를 재활성화하는 것은 이번 범위 밖).
+- `argocd-rbac-policy` ExternalSecret이 `creationPolicy: Merge`로 존재하지 않는 Secret `argocd-rbac-cm`에 병합을 시도하다 `SecretSyncedError` 발생. 이관 이전부터 있던 차트 설정 이슈로 보이며, 이번 이관 범위에서는 수정하지 않고 발견 사항으로만 기록.
+- `hotsao`의 cron 파드들이 일시적으로 `Insufficient cpu`로 Pending (전체 앱이 동시에 최초 부트스트랩되며 발생한 일시적 현상, `spot_pool_large`가 2→3 노드로 오토스케일되며 자연 해소됨).
 
-이후 ArgoCD가 나머지 앱들(Istio, cert-manager, 애플리케이션들)을 자동으로 배포.
+### Phase 5 - DNS 전환 및 검증 — **부분 완료 (실제 트래픽 전환은 아직 안 됨)**
 
-### Phase 5 - DNS 전환 및 검증
+- [x] 새 Istio Ingress Gateway 외부 IP 확인 (`34.64.94.80`)
+- [x] Cloud DNS 존 5개(`ggorockee-com`, `ggorockee-org`, `hotsao-com`, `review-maps-com`, `woohalabs-com`)를 `yango-501407`에 생성, A레코드(root+wildcard)를 새 IP로 설정
+- [x] HTTPS 인증서 발급 확인 (ggorockee.com, hotsao.com, review-maps.com, woohalabs.com 4개 모두 발급 완료)
+- [x] 각 앱 정상 동작 확인 (ojeomneo, reviewmaps, hotsao — 클러스터 내부에서 파드/DB 연결 기준. sybot/yangobot은 파드 Healthy 확인, 도메인 통한 외부 접근은 미검증)
+- [ ] 모니터링 스택 확인 — **해당 없음**: Prometheus/Grafana/Loki는 저장소에서 의도적으로 비활성화된 상태 (`charts/argocd/configurations/prod/legacy/monitoring-kube-prometheus-stack.yaml.monitoring`, PR #1035에서 제거). 이관과 무관한 기존 상태.
+- [ ] **DNS 레코드 실제 전환 (레지스트라/Cloudflare 레벨) — 미실행**
 
-- [ ] 새 Istio Ingress Gateway 외부 IP 확인
-- [ ] DNS 레코드를 새 IP로 변경 (TTL 낮춤 → 전환 → 확인 후 TTL 복원)
-- [ ] HTTPS 인증서 발급 확인
-- [ ] 각 앱 정상 동작 확인 (ojeomneo, reviewmaps, hotsao, sybot, yangobot)
-- [ ] 모니터링 스택 확인 (Prometheus, Grafana, Loki, SigNoz)
+**중요**: 각 도메인의 실제 권위 DNS는 Google Cloud DNS가 아니라 **Cloudflare**임 (`isaac.ns.cloudflare.com`, `hope.ns.cloudflare.com`). 위에서 만든 `yango-501407`의 Cloud DNS 존은 실제 트래픽에는 전혀 영향을 주지 않으며, 오직 `_acme-challenge.<domain>` 서브도메인만 Cloudflare에서 Google Cloud DNS로 NS 위임되어 있어 (사용자가 직접 설정) SSL 인증서 발급 자동화 용도로만 쓰이는 상태. **실제 트래픽을 새 클러스터로 전환하려면 Cloudflare에서 각 도메인의 A 레코드(root + wildcard)를 `34.64.94.80`으로 직접 변경해야 함** — 이 작업은 아직 진행되지 않았고, 실제 서비스 다운타임/전환 리스크가 있는 단계라 사용자 확인 후 진행 필요.
+
+**실행 중 발견/해결한 이슈**:
+
+- `cert-manager-dns01-key` 시크릿이 옛 프로젝트(`yango-495502`) 소속 서비스 계정 키였음 — 그대로 쓰면 Phase 6에서 구 프로젝트 삭제 시 인증서 갱신이 깨짐. 새 프로젝트에 `cert-manager-dns01@yango-501407` 서비스 계정을 새로 만들어 `roles/dns.admin` 부여 후 키 교체.
+- DNS-01 챌린지가 계속 `403 Forbidden`으로 실패했던 최초 원인은 위 서비스 계정 문제였고, 그 다음 발견된 근본 원인이 Cloudflare 권위 DNS 문제였음. 사용자가 Cloudflare에서 `_acme-challenge` 서브도메인 NS 위임을 설정한 뒤 정상적으로 발급됨.
 
 **검증 체크리스트:**
 
-| 서비스 | 확인 방법 |
-|--------|---------|
-| ArgoCD | 로그인 확인 |
-| Ojeomneo | 앱 정상 동작 |
-| ReviewMaps | 앱 정상 동작 |
-| Hotsao | 앱 정상 동작 |
-| Sybot | 앱 정상 동작 |
-| Yangobot | 앱 정상 동작 |
-| Grafana | 대시보드 확인 |
+| 서비스 | 확인 방법 | 결과 |
+|--------|---------|------|
+| ArgoCD | 로그인 확인 | 미검증 (도메인 미전환) |
+| Ojeomneo | 앱 정상 동작 | 클러스터 내부 기준 정상 |
+| ReviewMaps | 앱 정상 동작 | 클러스터 내부 기준 정상 |
+| Hotsao | 앱 정상 동작 | 클러스터 내부 기준 정상 |
+| Yangobot | 앱 정상 동작 | 파드 Healthy |
+| Grafana | 대시보드 확인 | 해당 없음 (모니터링 스택 비활성화 상태) |
 
 ### Phase 6 - 기존 프로젝트 정리
 
@@ -165,6 +173,9 @@
 | `charts/helm/prod/cert-manager/values.yaml` | `clusterIssuer.gcpProjectId`를 `yango-501407`로 변경 (Cloud DNS-01 solver) |
 | `charts/helm/prod/kube-prometheus-stack/values-override.yaml` | `clusterSecretStore.gcpProjectID`, `gcpServiceAccount`를 `yango-501407` 기준으로 변경 (기존에 `infra-480802`로 남아있던 죽은 참조 정리, 현재 `enabled: false`로 Terraform이 관리하므로 실동작에는 영향 없음) |
 | `charts/helm/prod/argo-cd/values.yaml` | `serviceAccount.annotations`의 `iam.gke.io/gcp-service-account`를 `argocd-prod@yango-501407.iam.gserviceaccount.com`으로 변경 (기존 `infra-480802` 참조는 Workload Identity 바인딩이 실제로 깨져 있던 값이었음) |
+| `gcp/terraform/environments/prod/main.tf` | 최초 부트스트랩을 위해 `external_secrets` 모듈을 일시 비활성화했다가 GKE 생성 후 재활성화 (2단계 커밋) |
+| `gcp/terraform/modules/cloud-sql/main.tf` | `null_resource`가 `POSTGRES_HOST`도 함께 갱신하도록 수정 (기존엔 `POSTGRES_SERVER`만 갱신하는 버그) |
+| `gcp/terraform/modules/gke/main.tf` | `spot_pool_medium`, `spot_pool_large`의 `node_count`에 `lifecycle.ignore_changes` 추가 (오토스케일러가 조정한 노드 수를 Terraform이 되돌리지 않도록) |
 
 ### GitHub Actions Secrets 변경 필요
 
@@ -184,9 +195,18 @@ GitHub Repository → Settings → Secrets and variables → Actions:
 - Spot 노드 사용으로 이관 중 노드 회수 가능성 있음 (GKE 배포 시 주의)
 - Workload Identity 바인딩은 Terraform apply 시 자동 설정됨 (`external-secrets-prod@`, `argocd-prod@` SA)
 - `kubernetes/jobs/cloud-sql-restore/*/service-account.yaml`은 Terraform 미관리 리소스라 수동으로 새 프로젝트 SA를 만들고 어노테이션을 갱신해야 함
+- 실제 도메인 권위 DNS는 Cloudflare이므로, Google Cloud DNS 존 생성만으로는 트래픽이 전혀 전환되지 않음 (SSL 인증서 자동 발급용 `_acme-challenge` 위임에만 사용됨)
+- `argocd-rbac-policy` ExternalSecret의 `SecretSyncedError`는 이관과 무관한 기존 이슈로 남아있음 (미수정)
+
+## 남은 작업 (다음 세션 참고용)
+
+- [ ] Cloudflare에서 각 도메인 A레코드를 `34.64.94.80`으로 변경 (실제 트래픽 전환, 사용자 승인 필요)
+- [ ] 전환 후 24시간 모니터링, 에러율/응답 확인
+- [ ] Phase 6: 7일 안정화 후 `yango-495502` 최종 백업 및 리소스 정리
+- [ ] `argocd-rbac-policy` ExternalSecret 설정 정리 (기존 이슈, 선택 사항)
 
 ## 최종 업데이트
 
 - 작성일: 2026-02-17 (구 → yango-495502 이관 기준)
-- 갱신일: 2026-07-04 (yango-495502 → yango-501407 이관 기준)
+- 갱신일: 2026-07-04 (yango-495502 → yango-501407 이관 기준, Phase 0~4 완료 및 Phase 5 부분 완료)
 - 이관 대상 프로젝트: `yango-501407`


### PR DESCRIPTION
## Summary
- claudedocs/migration-to-new-gcp.md를 실제 이관 실행 결과 기준으로 갱신
- Phase 0~4 완료 체크, Phase 5는 SSL 인증서 발급까지만 완료되고 실제 Cloudflare A레코드 전환은 아직 안 된 상태임을 명확히 기록
- 이관 중 발견한 버그와 조치 내역 정리 (POSTGRES_HOST 미갱신, hotsao DB 누락, node_count 오토스케일 드리프트, cert-manager 옛 프로젝트 SA 키 등)

## Test plan
- 문서 변경만 포함, 인프라 영향 없음